### PR TITLE
Refine UI to keep the buttons always centered

### DIFF
--- a/ComponentMissingMessageForm.Designer.cs
+++ b/ComponentMissingMessageForm.Designer.cs
@@ -58,9 +58,10 @@ partial class ComponentMissingMessageForm
             // 
             // btnExit
             // 
-            this.btnExit.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.btnExit.Location = new System.Drawing.Point(90, 89);
             this.btnExit.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnExit.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.btnExit.Name = "btnExit";
             this.btnExit.Size = new System.Drawing.Size(114, 27);
             this.btnExit.TabIndex = 3;

--- a/IncompatibleGPUMessageForm.Designer.cs
+++ b/IncompatibleGPUMessageForm.Designer.cs
@@ -39,7 +39,8 @@
             // 
             // btnRunDX
             // 
-            this.btnRunDX.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRunDX.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.btnRunDX.DialogResult = System.Windows.Forms.DialogResult.No;
             this.btnRunDX.Location = new System.Drawing.Point(99, 299);
             this.btnRunDX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -97,7 +98,8 @@
             // 
             // btnRunXNAOnce
             // 
-            this.btnRunXNAOnce.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRunXNAOnce.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.btnRunXNAOnce.DialogResult = System.Windows.Forms.DialogResult.Yes;
             this.btnRunXNAOnce.Location = new System.Drawing.Point(99, 265);
             this.btnRunXNAOnce.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -109,7 +111,8 @@
             // 
             // button1
             // 
-            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.button1.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.button1.Location = new System.Drawing.Point(99, 332);
             this.button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);

--- a/Program.cs
+++ b/Program.cs
@@ -69,6 +69,12 @@ internal sealed class Program
                 return;
             }
 
+            if (args.Any(q => q.Equals("-DialogTest", StringComparison.OrdinalIgnoreCase)))
+            {
+                RunDialogTest();
+                return;
+            }
+
             AutoRun();
         }
         catch (Exception ex)
@@ -76,6 +82,23 @@ internal sealed class Program
             MessageBox.Show(ex.ToString(), "Client Launcher Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             Environment.Exit(1);
         }
+    }
+
+    private static void RunDialogTest()
+    {
+        MessageBox.Show(
+            "Message text here",
+            "Message caption here",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Error);
+
+        using var incompatibleGpuForm = new IncompatibleGPUMessageForm();
+        SetLinkLabelUrl(incompatibleGpuForm.lblXNALink, new Uri("https://example.com"));
+        incompatibleGpuForm.ShowDialog();
+
+        using var messageForm = new ComponentMissingMessageForm();
+        SetLinkLabelUrl(messageForm.lblLink, new Uri("https://example.com"));
+        messageForm.ShowDialog();
     }
 
     private static void RunXNA()


### PR DESCRIPTION
The button does not keep centered depending on the system default font (depends on user's language) and also the monitor dpi. Update anchors to keep the button centered. See the screenshot below.

![Snipaste_2023-01-23_15-07-01](https://user-images.githubusercontent.com/11227602/213983230-f7c958bf-1bb1-4fd4-b473-912ec86275b3.png)

This PR also added a `-DialogTest` command so three different windows pop up to test the UI.
