### PR TITLE
Revert By default use 32bit runtime when 64bit runtime is not installed

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,8 +32,6 @@ internal sealed class Program
         { (Architecture.Arm64, true), DotNetArm64DesktopRuntimeDownloadLink }
     };
 
-    private static bool automaticX86Fallback;
-
     [STAThread]
     private static void Main(string[] args)
     {
@@ -42,7 +40,6 @@ internal sealed class Program
 #if DEBUG
             RunDialogTest();
 #else
-            automaticX86Fallback = !args.Any(q => q.Equals("-64Bit", StringComparison.OrdinalIgnoreCase));
 
             if (args.Any(q => q.Equals("-XNA", StringComparison.OrdinalIgnoreCase)))
             {
@@ -224,8 +221,6 @@ internal sealed class Program
     {
         // Architectures to be searched for
         List<Architecture> architectures = new() { machineArchitecture };
-        if (automaticX86Fallback && machineArchitecture != Architecture.X86)
-            architectures.Add(Architecture.X86);
 
         // Search for installed dotnet architectures
         Architecture? availableArchitecture = null;

--- a/Program.cs
+++ b/Program.cs
@@ -171,16 +171,15 @@ internal sealed class Program
                 {
                     case 0:
                         OpenUri(XnaDownloadLink);
-                        break;
+                        return;
                     case 1:
                         RunXNA();
-                        break;
+                        return;
                     case 2:
                         dxFailFile.Delete();
                         oglFailFile.Delete();
                         AutoRun();
-                        break;
-                    case 3:
+                        return;
                     default:
                         Environment.Exit(4);
                         return;
@@ -188,6 +187,7 @@ internal sealed class Program
             }
 
             RunOGL();
+            return;
         }
 
         RunDX();

--- a/README.md
+++ b/README.md
@@ -19,7 +19,3 @@ Do not autoselect a version, run the WinForms XNA client:
 ```
 -XNA
 ```
-Perform 64bit dotnet runtime check instead of automatically falling back to 32bit dotnet runtime:
-```
--64Bit
-```


### PR DESCRIPTION
There is a scenario that warrants this removal:

If a user has only the x86 net7 runtime installed and a x64 PRE-net7 (net6) runtime installed, this scenario will happen. 
The issue is that once we get to the new net7 updater, it by default simply calls `dotnet secondstageupater.dll` to perform the update. The problem is that the x64 net6 runtime in the scenario above will be called in this case, because the PATH variable will default to it.

Steps to reproduce: 
- Make sure that only the following versions of dotnet are installed:
    - .net4 (required to be running the net4 based client anyways)
    - .net7 x86
    - .net6 x64
- Make sure the client is the current net4 version of the client (for example, this might be client version 8.0)
- Update the client to the net7 version of the client (for example, this might be client version 9.0)
- Push a change that would create a NEW net7 version of the client. (for example, this might be version 9.1). 
- Restart the client (you should still be on the example client version 9.0)
- You should be prompted to update to the next net7 version of the client (example client version 9.1). Accept the update.
- Verify that the client update fails.

This is because once we've made it to the first client version that is on net7 (client version 9.0 in the example above), the updater attempts to call `dotnet secondstageupdater.dll` for the next update. With the currently installed versions of dotnet above, the PATH variable will default to the x64 net6 installation. So, calling `dotnet seconddstageupdater.dll` will attempt to use this x64 net6 dotnet which will be unable to launch the net7 based instance of the `secondstageupdater.dll`

Being that the client launcher is the starting point for ALL that is the user experience of the client (the client itself, the updater, etc...), it makes the most sense to put this necessary check into the launcher itself, rather than the updater. It'll also yep facilitate the possible and eventual move to a net7 launcher.