### PR TITLE
Unblock Internet files on startup

### DIFF
--- a/NativeConstants.cs
+++ b/NativeConstants.cs
@@ -3,8 +3,8 @@
 internal static class NativeConstants
 {
     /// ERROR_FILE_NOT_FOUND -> 2L
-    public const uint ERROR_FILE_NOT_FOUND = 2;
+    public const int ERROR_FILE_NOT_FOUND = 2;
 
     /// ERROR_ACCESS_DENIED -> 5L
-    public const uint ERROR_ACCESS_DENIED = 5;
+    public const int ERROR_ACCESS_DENIED = 5;
 }

--- a/NativeConstants.cs
+++ b/NativeConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace CnCNet.LauncherStub;
+
+internal static class NativeConstants
+{
+    /// ERROR_FILE_NOT_FOUND -> 2L
+    public const uint ERROR_FILE_NOT_FOUND = 2;
+
+    /// ERROR_ACCESS_DENIED -> 5L
+    public const uint ERROR_ACCESS_DENIED = 5;
+}

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -1,0 +1,19 @@
+﻿namespace CnCNet.LauncherStub;
+
+using System.Runtime.InteropServices;
+
+internal static class NativeMethods
+{
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+#if NET45_OR_GREATER
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+#endif
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool DeleteFile(string name);
+
+    [DllImport("kernel32.dll", EntryPoint = "GetLastError")]
+#if NET45_OR_GREATER
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+#endif
+    public static extern uint GetLastError();
+}

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 internal static class NativeMethods
 {
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-#if NET45_OR_GREATER
+#if NET45_OR_GREATER || NETSTANDARD || NET
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
 #endif
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -10,10 +10,4 @@ internal static class NativeMethods
 #endif
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool DeleteFile(string name);
-
-    [DllImport("kernel32.dll", EntryPoint = "GetLastError")]
-#if NET45_OR_GREATER
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-#endif
-    public static extern uint GetLastError();
 }

--- a/Program.cs
+++ b/Program.cs
@@ -174,6 +174,8 @@ internal sealed class Program
 
     private static void RemoveZoneIdentifer(string directory)
     {
+        // https://stackoverflow.com/a/6375373
+
         List<string> failedFiles = [];
 
         // Enumerate all files recursively

--- a/Program.cs
+++ b/Program.cs
@@ -94,7 +94,12 @@ internal sealed class Program
         }
         catch (Exception ex)
         {
-            AdvancedMessageBoxHelper.ShowOkMessageBox("An error occured when the launcher tries to unblock files. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(), "Client Launcher Warning", okText: "Continue");
+            bool ignoreUnblocking = AdvancedMessageBoxHelper.ShowYesNoMessageBox(
+                   "An error occured when the launcher tries to unblock files. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(),
+                   "Client Launcher Warning",
+                   yesText: "Continue", noText: "Exit");
+            if (!ignoreUnblocking)
+                Environment.Exit(1);
         }
 
         try

--- a/Program.cs
+++ b/Program.cs
@@ -95,9 +95,10 @@ internal sealed class Program
         catch (Exception ex)
         {
             bool ignoreUnblocking = AdvancedMessageBoxHelper.ShowYesNoMessageBox(
-                   "An error occured when the launcher tries to unblock files. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(),
+                   "An error occured when the launcher tried to unblock files. Re-running the launcher with administrator privileges might help.\n\n" + ex.ToString(),
                    "Client Launcher Warning",
                    yesText: "Continue", noText: "Exit");
+
             if (!ignoreUnblocking)
                 Environment.Exit(1);
         }

--- a/Program.cs
+++ b/Program.cs
@@ -93,7 +93,7 @@ internal sealed class Program
         }
         catch (Exception ex)
         {
-            AdvancedMessageBoxHelper.ShowOkMessageBox("An error occured when the launcher tries to unlock files downloaded from Internet. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(), "Client Launcher Warning", okText: "Continue");
+            AdvancedMessageBoxHelper.ShowOkMessageBox("An error occured when the launcher tries to unblock files downloaded from Internet. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(), "Client Launcher Warning", okText: "Continue");
         }
 
         try

--- a/Program.cs
+++ b/Program.cs
@@ -94,7 +94,7 @@ internal sealed class Program
         }
         catch (Exception ex)
         {
-            AdvancedMessageBoxHelper.ShowOkMessageBox("An error occured when the launcher tries to unblock files downloaded from Internet. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(), "Client Launcher Warning", okText: "Continue");
+            AdvancedMessageBoxHelper.ShowOkMessageBox("An error occured when the launcher tries to unblock files. Re-run the launcher with administrator privileges might help.\n" + ex.ToString(), "Client Launcher Warning", okText: "Continue");
         }
 
         try

--- a/Program.cs
+++ b/Program.cs
@@ -179,7 +179,7 @@ internal sealed class Program
         msgbox.ShowDialog();
     }
 
-    private static void RemoveZoneIdentifer(string directory, int stopOnErrorCount = 10)
+    private static void RemoveZoneIdentifer(string directory)
     {
         // https://stackoverflow.com/a/6375373
 
@@ -202,10 +202,7 @@ internal sealed class Program
 
                 string errorMessage = new Win32Exception(error).Message;
 
-                failedMessages.Add($"{file} - {errorMessage}");
-
-                if (failedMessages.Count >= stopOnErrorCount)
-                    break;
+                failedMessages.Add($"{file}: {errorMessage}");
             }
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -173,7 +173,7 @@ internal sealed class Program
         msgbox.ShowDialog();
     }
 
-    private static void RemoveZoneIdentifer(string directory)
+    private static void RemoveZoneIdentifer(string directory, int stopOnErrorCount = 10)
     {
         // https://stackoverflow.com/a/6375373
 
@@ -197,6 +197,9 @@ internal sealed class Program
                 string errorMessage = new Win32Exception(error).Message;
 
                 failedMessages.Add($"{file} - {errorMessage}");
+
+                if (failedMessages.Count >= stopOnErrorCount)
+                    break;
             }
         }
 


### PR DESCRIPTION
Fixes #14.

Test procedures:

1. As an example, install [Project Phantom](https://projectphantom.net/download/)
2. Go to https://github.com/CnCNet/xna-cncnet-client/pull/555#issuecomment-2335351236 and download "artifacts-Ares.zip" file using a browser, like Firefox.
3. Extract this zip file using latest WinRAR. Override the Resources folder. Note that files such as clientdx.exe and ClientGUI.dll etc should be overwritten during this step.
4. Open "Properties" for `clientdx.exe` file. The file should be locked. Same for other exe files. (The launcher will not assume file extensions but at least from my view only exe files are locked.)
6. Run the launcher.
7. Open "Properties" for `clientdx.exe` file. The file should be unlocked.

Also, if "clientdx.exe" resides in a folder requring administrator privileges, like `C:\Program Files (x86)\<game folder>`, the launcher would need such privileges to unlock files. In this case, if the launcher failed to unlock files, it will prompt a warning as follows.

![Snipaste_2024-09-09_22-55-22](https://github.com/user-attachments/assets/5e6f8ba4-b79b-4d15-b201-08a1653a3df1)

