### PR TITLE
Enforce standard using directive placement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Remove the line below if you want to inherit .editorconfig settings from higher directories
+﻿# Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
 # C# files
@@ -126,7 +126,7 @@ csharp_style_unused_value_assignment_preference = discard_variable:warning
 csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
 
 # 'using' directive preferences
-csharp_using_directive_placement = inside_namespace:warning
+csharp_using_directive_placement = outside_namespace:error
 
 # New line preferences
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning

--- a/AdvancedMessageBox.xaml.cs
+++ b/AdvancedMessageBox.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Windows;
+﻿using System.Windows;
 
 namespace CnCNet.LauncherStub;
 /// <summary>

--- a/AdvancedMessageBox.xaml.cs
+++ b/AdvancedMessageBox.xaml.cs
@@ -1,7 +1,7 @@
-﻿namespace CnCNet.LauncherStub;
-
+﻿
 using System.Windows;
 
+namespace CnCNet.LauncherStub;
 /// <summary>
 /// Interaction logic for AdvancedMessageBox.xaml.
 /// </summary>

--- a/AdvancedMessageBoxHelper.cs
+++ b/AdvancedMessageBoxHelper.cs
@@ -1,7 +1,7 @@
-﻿namespace CnCNet.LauncherStub;
-
+﻿
 using System.Collections.ObjectModel;
 
+namespace CnCNet.LauncherStub;
 public static class AdvancedMessageBoxHelper
 {
     public static int? ShowMessageBoxWithSelection(string message, string title, string[] selections)

--- a/AdvancedMessageBoxHelper.cs
+++ b/AdvancedMessageBoxHelper.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace CnCNet.LauncherStub;
 public static class AdvancedMessageBoxHelper

--- a/AdvancedMessageBoxViewModel.cs
+++ b/AdvancedMessageBoxViewModel.cs
@@ -1,7 +1,7 @@
-﻿namespace CnCNet.LauncherStub;
-
+﻿
 using System.Collections.ObjectModel;
 
+namespace CnCNet.LauncherStub;
 public class AdvancedMessageBoxViewModel : NotifyPropertyChangedBase
 {
     private ObservableCollection<CommandViewModel>? commands;

--- a/AdvancedMessageBoxViewModel.cs
+++ b/AdvancedMessageBoxViewModel.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace CnCNet.LauncherStub;
 public class AdvancedMessageBoxViewModel : NotifyPropertyChangedBase

--- a/CnCNet.LauncherStub.csproj
+++ b/CnCNet.LauncherStub.csproj
@@ -21,6 +21,7 @@
     <ApplicationIcon>mainclienticon.ico</ApplicationIcon>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CommandViewModel.cs
+++ b/CommandViewModel.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace CnCNet.LauncherStub;
 public class CommandViewModel : NotifyPropertyChangedBase

--- a/CommandViewModel.cs
+++ b/CommandViewModel.cs
@@ -1,7 +1,7 @@
-﻿namespace CnCNet.LauncherStub;
-
+﻿
 using System.Windows.Input;
 
+namespace CnCNet.LauncherStub;
 public class CommandViewModel : NotifyPropertyChangedBase
 {
     private string? text;

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace CnCNet.LauncherStub;
 internal static class NativeMethods

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -1,7 +1,7 @@
-﻿namespace CnCNet.LauncherStub;
-
+﻿
 using System.Runtime.InteropServices;
 
+namespace CnCNet.LauncherStub;
 internal static class NativeMethods
 {
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/NotifyPropertyChangedBase.cs
+++ b/NotifyPropertyChangedBase.cs
@@ -1,7 +1,7 @@
-﻿namespace CnCNet.LauncherStub;
-
+﻿
 using System.ComponentModel;
 
+namespace CnCNet.LauncherStub;
 public abstract class NotifyPropertyChangedBase : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/NotifyPropertyChangedBase.cs
+++ b/NotifyPropertyChangedBase.cs
@@ -1,5 +1,4 @@
-﻿
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace CnCNet.LauncherStub;
 public abstract class NotifyPropertyChangedBase : INotifyPropertyChanged

--- a/Program.cs
+++ b/Program.cs
@@ -1,17 +1,13 @@
-﻿namespace CnCNet.LauncherStub;
-
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using CnCNet.LauncherStub.LocalizationResources;
 using Microsoft.Win32;
 
+namespace CnCNet.LauncherStub;
 internal sealed class Program
 {
     private const string Resources = "Resources";

--- a/RelayCommand.cs
+++ b/RelayCommand.cs
@@ -1,8 +1,6 @@
-﻿namespace CnCNet.LauncherStub;
+﻿using System.Windows.Input;
 
-using System;
-using System.Windows.Input;
-
+namespace CnCNet.LauncherStub;
 public class RelayCommand : ICommand
 {
     private readonly Action<object> execute;


### PR DESCRIPTION
This change updates the EditorConfig rule for `csharp_using_directive_placement` from `inside_namespace:warning` to `outside_namespace:error`, aligning with the .NET default recommendation. This PR also enables `ImplicitUsings`.

**Motivation**

In projects that use file-scoped namespace declarations (e.g. namespace A;), placing using directives inside the namespace can lead to unexpected name resolution behavior. For example:

```csharp
namespace A.System;

using System;     // This imports A.System, not the global System namespace
```

